### PR TITLE
Use contains, not suboptions, in returns documentation (contributes to #67)

### DIFF
--- a/plugins/modules/external_ordering_service.py
+++ b/plugins/modules/external_ordering_service.py
@@ -149,7 +149,7 @@ ordering_service:
         - The ordering service, as a list of ordering service nodes.
     type: list
     elements: dict
-    suboptions:
+    contains:
         name:
             description:
                 - The name of the ordering service node.

--- a/plugins/modules/external_organization.py
+++ b/plugins/modules/external_organization.py
@@ -216,7 +216,7 @@ organization:
     description:
         - The organization.
     type: dict
-    suboptions:
+    contains:
         name:
             description:
                 - The name of the organization.
@@ -261,7 +261,7 @@ organization:
             description:
                 - Configuration specific to the identity classification.
             type: dict
-            suboptions:
+            contains:
                 enable:
                     description:
                         - True if identity classification is enabled for this organization, false otherwise.
@@ -271,7 +271,7 @@ organization:
                     description:
                         - Configuration specific to the admin identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -286,7 +286,7 @@ organization:
                     description:
                         - Configuration specific to the client identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -301,7 +301,7 @@ organization:
                     description:
                         - Configuration specific to the peer identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -316,7 +316,7 @@ organization:
                     description:
                         - Configuration specific to the orderer identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.

--- a/plugins/modules/ordering_service.py
+++ b/plugins/modules/ordering_service.py
@@ -217,7 +217,7 @@ ordering_service:
         - The ordering service, as a list of ordering service nodes.
     type: list
     elements: dict
-    suboptions:
+    contains:
         name:
             description:
                 - The name of the ordering service node.

--- a/plugins/modules/ordering_service_info.py
+++ b/plugins/modules/ordering_service_info.py
@@ -76,7 +76,7 @@ ordering_service:
         - The ordering service, as a list of ordering service nodes.
     type: list
     elements: dict
-    suboptions:
+    contains:
         name:
             description:
                 - The name of the ordering service node.

--- a/plugins/modules/organization.py
+++ b/plugins/modules/organization.py
@@ -205,7 +205,7 @@ organization:
     description:
         - The organization.
     type: dict
-    suboptions:
+    contains:
         name:
             description:
                 - The name of the organization.
@@ -250,7 +250,7 @@ organization:
             description:
                 - Configuration specific to the identity classification.
             type: dict
-            suboptions:
+            contains:
                 enable:
                     description:
                         - True if identity classification is enabled for this organization, false otherwise.
@@ -260,7 +260,7 @@ organization:
                     description:
                         - Configuration specific to the admin identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -275,7 +275,7 @@ organization:
                     description:
                         - Configuration specific to the client identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -290,7 +290,7 @@ organization:
                     description:
                         - Configuration specific to the peer identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -305,7 +305,7 @@ organization:
                     description:
                         - Configuration specific to the orderer identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.

--- a/plugins/modules/organization_info.py
+++ b/plugins/modules/organization_info.py
@@ -71,7 +71,7 @@ organization:
     description:
         - The organization.
     type: dict
-    suboptions:
+    contains:
         name:
             description:
                 - The name of the organization.
@@ -116,7 +116,7 @@ organization:
             description:
                 - Configuration specific to the identity classification.
             type: dict
-            suboptions:
+            contains:
                 enable:
                     description:
                         - True if identity classification is enabled for this organization, false otherwise.
@@ -126,7 +126,7 @@ organization:
                     description:
                         - Configuration specific to the admin identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -141,7 +141,7 @@ organization:
                     description:
                         - Configuration specific to the client identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -156,7 +156,7 @@ organization:
                     description:
                         - Configuration specific to the peer identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.
@@ -171,7 +171,7 @@ organization:
                     description:
                         - Configuration specific to the orderer identity classification.
                     type: dict
-                    suboptions:
+                    contains:
                         certificate:
                             description:
                                 - The root or intermediate certificate for this identity classification.


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>