### PR TITLE
Add console role with support for Red Hat OpenShift (contributes to #125)

### DIFF
--- a/docs/source/roles/console.rst
+++ b/docs/source/roles/console.rst
@@ -1,0 +1,149 @@
+..
+.. SPDX-License-Identifier: Apache-2.0
+..
+
+:github_url: https://github.com/IBM-Blockchain/ansible-collection/edit/master/docs/source/roles/endorsing_organization.rst
+
+
+console -- Deploy the IBM Blockchain Platform console into Kubernetes or Red Hat OpenShift
+==========================================================================================
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+This role allows you to quickly deploy the IBM Blockchain Platform console.
+
+This role works with both Kubernetes clusters and Red Hat OpenShift clusters, running on either x86-64 or IBM Z hardware.
+
+Parameters
+----------
+
+  state (optional, str, present)
+    ``absent`` - All components for the console will be stopped and removed, if they exist.
+
+    ``present`` - All components for the console will be created if they do not exist, or will be updated if their current configuration does not match the expected configuration.
+
+  target (required, str, None)
+    ``k8s`` - Deploy the console into a Kubernetes cluster.
+
+    ``openshift`` - Deploy the console into a Red Hat OpenShift cluster.
+
+  arch (required, str, None)
+    ``amd64`` - Specify this if the architecture of the cluster is amd64.
+
+    ``s390x`` - Specify this if the architecture of the cluster is s390x.
+
+  namespace (required, str, None)
+    The name of the Kubernetes namespace to deploy the console to. The namespace will be created if it does not exist.
+
+    Only required when *target* is ``k8s``.
+
+  project (required, str, None)
+    The name of the Red Hat OpenShift project to deploy the console to. The project will be created if it does not exist.
+
+    Only required when *target* is ``openshift``.
+
+  image_pull_secret (optional, str, docker-key-secret)
+    The name of the image pull secret. The image pull secret will be used to pull all IBM Blockchain Platform images from the specified image registry.
+
+  image_registry (optional, str, cp.icr.io)
+    The image registry to pull images from. The image registry must contain the IBM Blockchain Platform images.
+
+    The default image registry, ``cp.icr.io``, is the standard IBM Entitlement Registry.
+
+    You only need to specify an alternative image registry if you are behind a firewall and cannot access the standard IBM Entitlement Registry.
+
+  image_registry_username (optional, str, cp)
+    The username for authenticating to the image registry.
+
+    The default image registry username, ``cp``, is the username for the standard IBM Entitlement Registry.
+
+    You only need to specify an alternative image registry username if you are using an alternative image registry.
+
+  image_registry_email (required, str, None)
+    The email address for authenticating to the image registry.
+
+    If you are using the default image registry, this is the email address you use to log in to the My IBM dashboard.
+
+  image_registry_password (required, str, None)
+    The password for authenticating to the image registry.
+
+    If you are using the default image registry, this is the entitlement key that you can obtain from the My IBM dashboard.
+
+  image_repository (optional, str, cp)
+    The image repository on the image registry to pull images from.
+
+    The default image repository, ``cp``, is the image repository for the standard IBM Entitlement Registry.
+
+    You only need to specify an alternative image repository if you are using an alternative image registry.
+
+  cluster_role (optional, str, None)
+    The name of the cluster role.
+
+    By default, the cluster role has the same name as the specified Kubernetes namespace or Red Hat OpenShift project.
+
+  cluster_role_binding (optional, str, None)
+    The name of the cluster role binding.
+
+    By default, the cluster role binding has the same name as the specified Kubernetes namespace or Red Hat OpenShift project.
+
+  security_context_constraints (optional, str, None)
+    The name of the security context constraints.
+
+    By default, the security context contraints have the same name as the specified Kubernetes namespace or Red Hat OpenShift project.
+
+    Only required when *target* is ``openshift``.
+
+  service_account (optional, str, default)
+    The name of the service account to use.
+
+  operator (optional, str, ibp-operator)
+    The name of the operator.
+
+  console (optional, str, ibp-console)
+    The name of the console.
+
+  console_domain (required, str, None)
+    The DNS domain for the console.
+
+    This DNS domain will be used as the base DNS domain for the console, as well as any certificate authorities, peers, and ordering services created using the console.
+
+  console_email (required, str, None)
+    The email address of the default console user.
+
+  console_default_password (required, str, None)
+    The default password for all console users, including the default console user.
+
+  console_storage_class (optional, str, default)
+    The storage class to use for the console.
+
+  console_storage_size (optional, str, 10Gi)
+    The storage size to use for the console.
+
+  wait_timeout (optional, str, 60)
+    The timeout, in seconds, to wait until the console is available.
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+Return Values
+-------------
+
+
+Status
+------
+
+- This is not guaranteed to have a backwards compatible interface. *[preview]*
+- This is maintained by community.
+
+Authors
+~~~~~~~
+
+- Simon Stone (@sstone1)

--- a/docs/source/roles/endorsing_organization.rst
+++ b/docs/source/roles/endorsing_organization.rst
@@ -18,7 +18,7 @@ Synopsis
 
 This role allows you to quickly build Hyperledger Fabric components for an endorsing organization. An endorsing organization has a certificate authority and a peer.
 
-This module works with the IBM Blockchain Platform managed service running in IBM Cloud, or the IBM Blockchain Platform software running in a Red Hat OpenShift or Kubernetes cluster.
+This role works with the IBM Blockchain Platform managed service running in IBM Cloud, or the IBM Blockchain Platform software running in a Red Hat OpenShift or Kubernetes cluster.
 
 Parameters
 ----------

--- a/docs/source/roles/ordering_organization.rst
+++ b/docs/source/roles/ordering_organization.rst
@@ -18,7 +18,7 @@ Synopsis
 
 This role allows you to quickly build Hyperledger Fabric components for an ordering organization. An ordering organization has a certificate authority and an ordering service.
 
-This module works with the IBM Blockchain Platform managed service running in IBM Cloud, or the IBM Blockchain Platform software running in a Red Hat OpenShift or Kubernetes cluster.
+This role works with the IBM Blockchain Platform managed service running in IBM Cloud, or the IBM Blockchain Platform software running in a Red Hat OpenShift or Kubernetes cluster.
 
 Parameters
 ----------

--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -1,0 +1,31 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+state: present
+# target: k8s | openshift
+# arch: amd64 | s390x
+# project: my-project
+# namespace: my-namespace
+
+image_pull_secret: docker-key-secret
+image_registry: cp.icr.io
+image_registry_username: cp
+# image_registry_email: user@example.org
+# image_registry_password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+image_repository: cp
+
+cluster_role: "{{ project | default(namespace) | default('') }}"
+cluster_role_binding: "{{ project | default(namespace) | default('') }}"
+security_context_constraints: "{{ project | default(namespace) | default('') }}"
+service_account: default
+operator: ibp-operator
+console: ibp-console
+
+# console_domain: example.org
+# console_email: user@example.org
+# console_default_password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+console_storage_class: default
+console_storage_size: 10Gi
+
+wait_timeout: 60

--- a/roles/console/tasks/create.yml
+++ b/roles/console/tasks/create.yml
@@ -1,0 +1,36 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fail if architecture not specified
+  fail:
+    msg: arch not specified or is not one of "amd64" or "s390x"
+  when: not arch is defined or not arch in ("amd64", "s390x")
+
+- name: Fail if image registry email not specified
+  fail:
+    msg: image_registry_email not specified
+  when: not image_registry_email is defined
+
+- name: Fail if image registry password not specified
+  fail:
+    msg: image_registry_password not specified
+  when: not image_registry_password is defined
+
+- name: Fail if console domain not specified
+  fail:
+    msg: console_domain not specified
+  when: not console_domain is defined
+
+- name: Fail if console email not specified
+  fail:
+    msg: console_email not specified
+  when: not console_email is defined
+
+- name: Fail if console default password not specified
+  fail:
+    msg: console_default_password not specified
+  when: not console_default_password is defined
+
+- name: Create console
+  include_tasks: "{{ target }}/create.yml"

--- a/roles/console/tasks/delete.yml
+++ b/roles/console/tasks/delete.yml
@@ -1,0 +1,6 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Delete console
+  include_tasks: "{{ target }}/delete.yml"

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -1,0 +1,16 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fail if target not specified
+  fail:
+    msg: target not specified or is not one of "k8s" or "openshift"
+  when: not target is defined or not target in ("k8s", "openshift")
+
+- name: Create console
+  include_tasks: "create.yml"
+  when: state == "present"
+
+- name: Delete console
+  include_tasks: "delete.yml"
+  when: state == "absent"

--- a/roles/console/tasks/openshift/create.yml
+++ b/roles/console/tasks/openshift/create.yml
@@ -1,0 +1,90 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fail if project not specified
+  fail:
+    msg: project not specified
+  when: not project is defined
+
+- name: Determine if project exists
+  k8s_info:
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ project }}"
+  register: project_info
+
+- name: Create project
+  k8s:
+    state: present
+    api_version: project.openshift.io/v1
+    kind: ProjectRequest
+    name: "{{ project }}"
+  when: not project_info.resources
+
+- name: Create security context constraints
+  k8s:
+    state: present
+    namespace: "{{ project }}"
+    resource_definition: "{{ lookup('template', 'openshift/security_context_constraints.yml.j2') }}"
+
+- name: Create cluster role
+  k8s:
+    state: present
+    namespace: "{{ project }}"
+    resource_definition: "{{ lookup('template', 'openshift/cluster_role.yml.j2') }}"
+
+- name: Create cluster role binding
+  k8s:
+    state: present
+    namespace: "{{ project }}"
+    resource_definition: "{{ lookup('template', 'openshift/cluster_role_binding.yml.j2') }}"
+
+- name: Create image secret
+  k8s:
+    state: present
+    namespace: "{{ project }}"
+    resource_definition: "{{ lookup('template', 'openshift/image_pull_secret.yml.j2') }}"
+
+- name: Create operator
+  k8s:
+    state: present
+    namespace: "{{ project }}"
+    resource_definition: "{{ lookup('template', 'openshift/operator.yml.j2') }}"
+    wait: yes
+    wait_timeout: "{{ wait_timeout }}"
+
+- name: Create console
+  k8s:
+    state: present
+    namespace: "{{ project }}"
+    resource_definition: "{{ lookup('template', 'openshift/console.yml.j2') }}"
+
+- name: Find console route
+  k8s_info:
+    namespace: "{{ project }}"
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: "{{ console }}-console"
+  register: console_route
+  until: console_route.resources
+  retries: "{{ wait_timeout }}"
+  delay: 1
+
+- name: Set console URL from console ingress
+  set_fact:
+    console_url: "https://{{ console_route.resources[0].spec.host }}"
+
+- name: Wait for console to start
+  uri:
+    url: "{{ console_url }}"
+    status_code: "200"
+    validate_certs: no
+  register: result
+  until: result.status == 200
+  retries: "{{ wait_timeout }}"
+  delay: 1
+
+- name: Print console URL
+  debug:
+    msg: IBM Blockchain Platform console available at {{ console_url }}

--- a/roles/console/tasks/openshift/delete.yml
+++ b/roles/console/tasks/openshift/delete.yml
@@ -1,0 +1,71 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fail if project not specified
+  fail:
+    msg: project not specified
+  when: not project is defined
+
+- name: Determine if project exists
+  k8s_info:
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ project }}"
+  register: project_info
+
+- name: Delete console
+  k8s:
+    state: absent
+    namespace: "{{ project }}"
+    api_version: ibp.com/v1alpha1
+    kind: IBPConsole
+    name: "{{ console }}"
+  when: project_info.resources
+
+- name: Delete operator
+  k8s:
+    state: absent
+    namespace: "{{ project }}"
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ operator }}"
+    wait: yes
+    wait_timeout: "{{ wait_timeout }}"
+  when: project_info.resources
+
+- name: Delete image secret
+  k8s:
+    state: absent
+    namespace: "{{ project }}"
+    api_version: v1
+    kind: Secret
+    name: "{{ image_pull_secret }}"
+  when: project_info.resources
+
+- name: Delete cluster role binding
+  k8s:
+    state: absent
+    namespace: "{{ project }}"
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: "{{ cluster_role_binding }}"
+  when: project_info.resources
+
+- name: Delete cluster role
+  k8s:
+    state: absent
+    namespace: "{{ project }}"
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    name: "{{ cluster_role }}"
+  when: project_info.resources
+
+- name: Delete security context constraints
+  k8s:
+    state: absent
+    namespace: "{{ project }}"
+    api_version: security.openshift.io/v1
+    kind: SecurityContextConstraints
+    name: "{{ security_context_constraints }}"
+  when: project_info.resources

--- a/roles/console/templates/openshift/cluster_role.yml.j2
+++ b/roles/console/templates/openshift/cluster_role.yml.j2
@@ -1,0 +1,91 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ cluster_role }}"
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - "*"
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumes
+  - events
+  - configmaps
+  - secrets
+  - ingresses
+  - roles
+  - rolebindings
+  - serviceaccounts
+  - nodes
+  - routes
+  - routes/custom-host
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - "{{ operator }}"
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ibp.com
+  resources:
+  - '*'
+  - ibpservices
+  - ibpcas
+  - ibppeers
+  - ibpfabproxies
+  - ibporderers
+  verbs:
+  - '*'
+- apiGroups:
+  - ibp.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/roles/console/templates/openshift/cluster_role_binding.yml.j2
+++ b/roles/console/templates/openshift/cluster_role_binding.yml.j2
@@ -1,0 +1,19 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ cluster_role_binding }}"
+subjects:
+- kind: ServiceAccount
+  name: "{{ service_account }}"
+  namespace: "{{ project }}"
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccounts:{{ project }}
+roleRef:
+  kind: ClusterRole
+  name: "{{ cluster_role }}"
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/console/templates/openshift/console.yml.j2
+++ b/roles/console/templates/openshift/console.yml.j2
@@ -1,0 +1,23 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: ibp.com/v1alpha1
+kind: IBPConsole
+metadata:
+  name: "{{ console }}"
+spec:
+  arch:
+  - "{{ arch }}"
+  license: accept
+  serviceAccountName: "{{ service_account }}"
+  email: "{{ console_email }}"
+  password: "{{ console_default_password }}"
+  registryURL: "{{ image_registry }}/{{ image_repository }}"
+  imagePullSecret: "{{ image_pull_secret }}"
+  networkinfo:
+    domain: "{{ console_domain }}"
+  storage:
+    console:
+      class: "{{ console_storage_class }}"
+      size: "{{ console_storage_size }}"

--- a/roles/console/templates/openshift/image_pull_secret.yml.j2
+++ b/roles/console/templates/openshift/image_pull_secret.yml.j2
@@ -1,0 +1,22 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ image_pull_secret }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: "{{
+    {
+      'auths': {
+        image_registry: {
+          'email': image_registry_email,
+          'username': image_registry_username,
+          'password': image_registry_password,
+          'auth': (image_registry_username ~ ':' ~ image_registry_password) | b64encode
+        }
+      }
+    } | to_json | b64encode
+  }}"

--- a/roles/console/templates/openshift/operator.yml.j2
+++ b/roles/console/templates/openshift/operator.yml.j2
@@ -1,0 +1,100 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ operator }}"
+  labels:
+    release: "operator"
+    helm.sh/chart: "ibm-ibp"
+    app.kubernetes.io/name: "ibp"
+    app.kubernetes.io/instance: "ibpoperator"
+    app.kubernetes.io/managed-by: "{{ operator }}"
+spec:
+  replicas: 1
+  strategy:
+    type: "Recreate"
+  selector:
+    matchLabels:
+      name: "{{ operator }}"
+  template:
+    metadata:
+      labels:
+        name: "{{ operator }}"
+        release: "operator"
+        helm.sh/chart: "ibm-ibp"
+        app.kubernetes.io/name: "ibp"
+        app.kubernetes.io/instance: "ibpoperator"
+        app.kubernetes.io/managed-by: "{{ operator }}"
+      annotations:
+        productName: "IBM Blockchain Platform"
+        productID: "54283fa24f1a4e8589964e6e92626ec4"
+        productVersion: "2.1.3"
+    spec:
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: "{{ service_account }}"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - "{{ arch }}"
+      imagePullSecrets:
+        - name: "{{ image_pull_secret }}"
+      containers:
+        - name: ibp-operator
+          image: "{{ image_registry }}/{{ image_repository }}/ibp-operator:2.1.3-20200324-{{ arch }}"
+          command:
+          - ibp-operator
+          imagePullPolicy: Always
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            runAsUser: 1001
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - CHOWN
+              - FOWNER
+          livenessProbe:
+            tcpSocket:
+              port: 8383
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8383
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "ibp-operator"
+            - name: CLUSTERTYPE
+              value: OPENSHIFT
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 100m
+              memory: 200Mi

--- a/roles/console/templates/openshift/security_context_constraints.yml.j2
+++ b/roles/console/templates/openshift/security_context_constraints.yml.j2
@@ -1,0 +1,41 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: "{{ security_context_constraints }}"
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- NET_BIND_SERVICE
+- CHOWN
+- DAC_OVERRIDE
+- SETGID
+- SETUID
+- FOWNER
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:authenticated
+- system:serviceaccounts:{{ project }}
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccounts:{{ project }}
+volumes:
+- "*"


### PR DESCRIPTION
Example:

```
- name: Deploy IBM Blockchain Platform console
  hosts: localhost
  vars:
    state: present
    target: openshift
    arch: amd64
    project: sstone1-delta
    image_registry_password: nothingtoseeherelol
    image_registry_email: sstone1@uk.ibm.com
    console_domain: apps.sstone1.os.fyre.ibm.com
    console_email: sstone1@uk.ibm.com
    console_default_password: nothingtoseehereeither
  roles:
    - ibm.blockchain_platform.console
```

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>