### PR TITLE
Extend console role with support for Kubernetes (contributes to #126)

### DIFF
--- a/docs/source/roles/console.rst
+++ b/docs/source/roles/console.rst
@@ -92,6 +92,20 @@ Parameters
 
     By default, the cluster role binding has the same name as the specified Kubernetes namespace or Red Hat OpenShift project.
 
+  pod_security_policy (optional, str, None)
+    The name of the pod security policy.
+
+    By default, the pod security policy has the same name as the specified Kubernetes namespace or Red Hat OpenShift project.
+
+    Only required when *target* is ``k8s``.
+
+  role_binding (optional, str, None)
+    The name of the role binding.
+
+    By default, the role binding has the same name as the specified Kubernetes namespace or Red Hat OpenShift project.
+
+    Only required when *target* is ``k8s``.
+
   security_context_constraints (optional, str, None)
     The name of the security context constraints.
 

--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -17,6 +17,8 @@ image_repository: cp
 
 cluster_role: "{{ project | default(namespace) | default('') }}"
 cluster_role_binding: "{{ project | default(namespace) | default('') }}"
+pod_security_policy: "{{ project | default(namespace) | default('') }}"
+role_binding: "{{ project | default(namespace) | default('') }}"
 security_context_constraints: "{{ project | default(namespace) | default('') }}"
 service_account: default
 operator: ibp-operator

--- a/roles/console/tasks/k8s/create.yml
+++ b/roles/console/tasks/k8s/create.yml
@@ -1,0 +1,96 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fail if namespace not specified
+  fail:
+    msg: namespace not specified
+  when: not namespace is defined
+
+- name: Determine if namespace exists
+  k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: namespace_info
+
+- name: Create namespace
+  k8s:
+    state: present
+    api_version: v1
+    kind: Namespace
+    name: "{{ namespace }}"
+  when: not namespace_info.resources
+
+- name: Create pod security policy
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/pod_security_policy.yml.j2') }}"
+
+- name: Create cluster role
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/cluster_role.yml.j2') }}"
+
+- name: Create cluster role binding
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/cluster_role_binding.yml.j2') }}"
+
+- name: Create role binding
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/role_binding.yml.j2') }}"
+
+- name: Create image secret
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/image_pull_secret.yml.j2') }}"
+
+- name: Create operator
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/operator.yml.j2') }}"
+    wait: yes
+    wait_timeout: "{{ wait_timeout }}"
+
+- name: Create console
+  k8s:
+    state: present
+    namespace: "{{ namespace }}"
+    resource_definition: "{{ lookup('template', 'k8s/console.yml.j2') }}"
+
+- name: Find console ingress
+  k8s_info:
+    namespace: "{{ namespace }}"
+    api_version: extensions/v1beta1
+    kind: Ingress
+    name: "{{ console }}"
+  register: console_route
+  until: console_route.resources
+  retries: "{{ wait_timeout }}"
+  delay: 1
+
+- name: Set console URL from console ingress
+  set_fact:
+    console_url: "https://{{ console_route.resources[0].spec.rules[0].host }}"
+
+- name: Wait for console to start
+  uri:
+    url: "{{ console_url }}"
+    status_code: "200"
+    validate_certs: no
+  register: result
+  until: result.status == 200
+  retries: "{{ wait_timeout }}"
+  delay: 1
+
+- name: Print console URL
+  debug:
+    msg: IBM Blockchain Platform console available at {{ console_url }}

--- a/roles/console/tasks/k8s/delete.yml
+++ b/roles/console/tasks/k8s/delete.yml
@@ -1,0 +1,80 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fail if namespace not specified
+  fail:
+    msg: namespace not specified
+  when: not namespace is defined
+
+- name: Determine if namespace exists
+  k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: namespace_info
+
+- name: Delete console
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: ibp.com/v1alpha1
+    kind: IBPConsole
+    name: "{{ console }}"
+  when: namespace_info.resources
+
+- name: Delete operator
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ operator }}"
+    wait: yes
+    wait_timeout: "{{ wait_timeout }}"
+  when: namespace_info.resources
+
+- name: Delete image secret
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: v1
+    kind: Secret
+    name: "{{ image_pull_secret }}"
+  when: namespace_info.resources
+
+- name: Delete role binding
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    name: "{{ role_binding }}"
+  when: namespace_info.resources
+
+- name: Delete cluster role binding
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: "{{ cluster_role_binding }}"
+  when: namespace_info.resources
+
+- name: Delete cluster role
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    name: "{{ cluster_role }}"
+  when: namespace_info.resources
+
+- name: Delete pod security policy
+  k8s:
+    state: absent
+    namespace: "{{ namespace }}"
+    api_version: policy/v1beta1
+    kind: PodSecurityPolicy
+    name: "{{ pod_security_policy }}"
+  when: namespace_info.resources

--- a/roles/console/tasks/openshift/create.yml
+++ b/roles/console/tasks/openshift/create.yml
@@ -71,7 +71,7 @@
   retries: "{{ wait_timeout }}"
   delay: 1
 
-- name: Set console URL from console ingress
+- name: Set console URL from console route
   set_fact:
     console_url: "https://{{ console_route.resources[0].spec.host }}"
 

--- a/roles/console/templates/k8s/cluster_role.yml.j2
+++ b/roles/console/templates/k8s/cluster_role.yml.j2
@@ -1,0 +1,77 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: "{{ cluster_role }}"
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - "{{ pod_security_policy }}"
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - "*"
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumes
+  - events
+  - configmaps
+  - secrets
+  - ingresses
+  - roles
+  - rolebindings
+  - serviceaccounts
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - 'get'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ibp.com
+  resources:
+  - '*'
+  - ibpservices
+  - ibpcas
+  - ibppeers
+  - ibpfabproxies
+  - ibporderers
+  verbs:
+  - '*'
+- apiGroups:
+  - ibp.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'

--- a/roles/console/templates/k8s/cluster_role_binding.yml.j2
+++ b/roles/console/templates/k8s/cluster_role_binding.yml.j2
@@ -1,0 +1,16 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ cluster_role_binding }}"
+subjects:
+- kind: ServiceAccount
+  name: "{{ service_account }}"
+  namespace: "{{ namespace }}"
+roleRef:
+  kind: ClusterRole
+  name: "{{ cluster_role }}"
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/console/templates/k8s/console.yml.j2
+++ b/roles/console/templates/k8s/console.yml.j2
@@ -1,0 +1,23 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: ibp.com/v1alpha1
+kind: IBPConsole
+metadata:
+  name: "{{ console }}"
+spec:
+  arch:
+  - "{{ arch }}"
+  license: accept
+  serviceAccountName: "{{ service_account }}"
+  email: "{{ console_email }}"
+  password: "{{ console_default_password }}"
+  registryURL: "{{ image_registry }}/{{ image_repository }}"
+  imagePullSecret: "{{ image_pull_secret }}"
+  networkinfo:
+    domain: "{{ console_domain }}"
+  storage:
+    console:
+      class: "{{ console_storage_class }}"
+      size: "{{ console_storage_size }}"

--- a/roles/console/templates/k8s/image_pull_secret.yml.j2
+++ b/roles/console/templates/k8s/image_pull_secret.yml.j2
@@ -1,0 +1,22 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ image_pull_secret }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: "{{
+    {
+      'auths': {
+        image_registry: {
+          'email': image_registry_email,
+          'username': image_registry_username,
+          'password': image_registry_password,
+          'auth': (image_registry_username ~ ':' ~ image_registry_password) | b64encode
+        }
+      }
+    } | to_json | b64encode
+  }}"

--- a/roles/console/templates/k8s/operator.yml.j2
+++ b/roles/console/templates/k8s/operator.yml.j2
@@ -1,0 +1,100 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ operator }}"
+  labels:
+    release: "operator"
+    helm.sh/chart: "ibm-ibp"
+    app.kubernetes.io/name: "ibp"
+    app.kubernetes.io/instance: "ibpoperator"
+    app.kubernetes.io/managed-by: "{{ operator }}"
+spec:
+  replicas: 1
+  strategy:
+    type: "Recreate"
+  selector:
+    matchLabels:
+      name: "{{ operator }}"
+  template:
+    metadata:
+      labels:
+        name: "{{ operator }}"
+        release: "operator"
+        helm.sh/chart: "ibm-ibp"
+        app.kubernetes.io/name: "ibp"
+        app.kubernetes.io/instance: "ibpoperator"
+        app.kubernetes.io/managed-by: "{{ operator }}"
+      annotations:
+        productName: "IBM Blockchain Platform"
+        productID: "54283fa24f1a4e8589964e6e92626ec4"
+        productVersion: "2.1.3"
+    spec:
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: "{{ service_account }}"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - "{{ arch }}"
+      imagePullSecrets:
+        - name: "{{ image_pull_secret }}"
+      containers:
+        - name: ibp-operator
+          image: "{{ image_registry }}/{{ image_repository }}/ibp-operator:2.1.3-20200324-{{ arch }}"
+          command:
+          - ibp-operator
+          imagePullPolicy: Always
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            runAsUser: 1001
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - CHOWN
+              - FOWNER
+          livenessProbe:
+            tcpSocket:
+              port: 8383
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8383
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "ibp-operator"
+            - name: CLUSTERTYPE
+              value: K8S
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 100m
+              memory: 200Mi

--- a/roles/console/templates/k8s/pod_security_policy.yml.j2
+++ b/roles/console/templates/k8s/pod_security_policy.yml.j2
@@ -1,0 +1,34 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ pod_security_policy }}"
+spec:
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: true
+  allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  requiredDropCapabilities:
+  - ALL
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  - CHOWN
+  - DAC_OVERRIDE
+  - SETGID
+  - SETUID
+  - FOWNER
+  volumes:
+  - '*'

--- a/roles/console/templates/k8s/role_binding.yml.j2
+++ b/roles/console/templates/k8s/role_binding.yml.j2
@@ -1,0 +1,16 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ role_binding }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ cluster_role }}"
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:{{ namespace }}


### PR DESCRIPTION
Example:

```
- name: Deploy IBM Blockchain Platform console
  hosts: localhost
  vars:
    state: present
    target: k8s
    arch: amd64
    namespace: sstone1-alpha
    image_registry_password: nothingtoseeherelol
    image_registry_email: sstone1@uk.ibm.com
    console_domain: 192-168-64-28.nip.io
    console_email: sstone1@uk.ibm.com
    console_default_password: nothingtoseehereeither
  roles:
    - ibm.blockchain_platform.console
```

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>