### PR TITLE
Allow console role to use existing TLS secret

### DIFF
--- a/docs/source/roles/console.rst
+++ b/docs/source/roles/console.rst
@@ -139,6 +139,13 @@ Parameters
   console_storage_size (optional, str, 10Gi)
     The storage size to use for the console.
 
+    console_tls_secret (optional, str, None)
+    The TLS secret name to use for the console.
+
+    If specified this secret must already exist in the specified Kubernetes namespace or Red Hat OpenShift project and must contain the TLS certificate and private key that the console will use.
+
+    If not specified the console will generate it's own self-signed certificates
+
   product_version (optional, str, 2.1.3)
     The version of IBM Blockchain Platform to use.
 

--- a/docs/source/roles/console.rst
+++ b/docs/source/roles/console.rst
@@ -139,7 +139,7 @@ Parameters
   console_storage_size (optional, str, 10Gi)
     The storage size to use for the console.
 
-    console_tls_secret (optional, str, None)
+  console_tls_secret (optional, str, None)
     The TLS secret name to use for the console.
 
     If specified this secret must already exist in the specified Kubernetes namespace or Red Hat OpenShift project and must contain the TLS certificate and private key that the console will use.

--- a/roles/console/templates/k8s/console.yml.j2
+++ b/roles/console/templates/k8s/console.yml.j2
@@ -21,3 +21,4 @@ spec:
     console:
       class: "{{ console_storage_class }}"
       size: "{{ console_storage_size }}"
+  tlsSecretName: "{{ console_tls_secret | default('') }}"

--- a/roles/console/templates/openshift/console.yml.j2
+++ b/roles/console/templates/openshift/console.yml.j2
@@ -21,3 +21,4 @@ spec:
     console:
       class: "{{ console_storage_class }}"
       size: "{{ console_storage_size }}"
+  tlsSecretName: "{{ console_tls_secret | default('') }}"


### PR DESCRIPTION
Allow console role to use an existing TLS secret containing existing tls.crt and tls.key.
Populates the tlsSecretName in the console.yml