### PR TITLE
Handle missing Python module errors (resolves #260)

### DIFF
--- a/plugins/module_utils/cert_utils.py
+++ b/plugins/module_utils/cert_utils.py
@@ -6,10 +6,14 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import Encoding
-from cryptography.x509.oid import ExtensionOID
+try:
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.serialization import Encoding
+    from cryptography.x509.oid import ExtensionOID
+except ImportError:
+    # Missing dependencies are handled elsewhere.
+    pass
 
 import base64
 import hashlib

--- a/plugins/module_utils/certificate_authorities.py
+++ b/plugins/module_utils/certificate_authorities.py
@@ -9,9 +9,14 @@ __metaclass__ = type
 from .enrolled_identities import EnrolledIdentity
 
 from ansible.module_utils.urls import open_url
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from hfc.fabric_ca.caservice import ca_service, Enrollment
+
+try:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from hfc.fabric_ca.caservice import ca_service, Enrollment
+except ImportError:
+    # Missing dependencies are handled elsewhere.
+    pass
 
 import base64
 import json

--- a/plugins/module_utils/module.py
+++ b/plugins/module_utils/module.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+HFC_IMPORT_ERR = None
+try:
+    import hfc  # noqa: F401
+    HAS_HFC = True
+except ImportError as e:
+    HAS_HFC = False
+    HFC_IMPORT_ERR = str(e)
+
+CRYPTOGRAPHY_IMPORT_ERR = None
+try:
+    import cryptography  # noqa: F401
+    HAS_CRYPTOGRAPHY = True
+except ImportError as e:
+    HAS_CRYPTOGRAPHY = False
+    CRYPTOGRAPHY_IMPORT_ERR = str(e)
+
+
+class BlockchainModule(AnsibleModule):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.check_for_missing_libs()
+
+    def check_for_missing_libs(self):
+        url = 'https://ibm-blockchain.github.io/ansible-collection/installation.html#requirements'
+        if not HAS_HFC:
+            self.fail_json(msg=missing_required_lib("fabric-sdk-py", url=url), exception=HFC_IMPORT_ERR)
+        if not HAS_CRYPTOGRAPHY:
+            self.fail_json(msg=missing_required_lib("cryptography", url=url), exception=CRYPTOGRAPHY_IMPORT_ERR)

--- a/plugins/modules/certificate_authority.py
+++ b/plugins/modules/certificate_authority.py
@@ -6,11 +6,12 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ..module_utils.dict_utils import copy_dict, diff_dicts, equal_dicts, merge_dicts
 from ..module_utils.certificate_authorities import CertificateAuthority
+from ..module_utils.dict_utils import copy_dict, diff_dicts, equal_dicts, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console
 
-from ansible.module_utils.basic import AnsibleModule, _load_params
+from ansible.module_utils.basic import _load_params
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -261,7 +262,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if)

--- a/plugins/modules/certificate_authority_info.py
+++ b/plugins/modules/certificate_authority_info.py
@@ -6,9 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_certificate_authority_by_name
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -139,7 +139,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/channel_block.py
+++ b/plugins/modules/channel_block.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.file_utils import get_temp_file, equal_files
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_identity_by_module, get_ordering_service_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import os
@@ -181,7 +181,7 @@ def main():
         ('api_authtype', 'basic', ['api_secret']),
         ('operation', 'fetch', ['api_endpoint', 'api_authtype', 'api_key', 'ordering_service', 'identity', 'msp_id', 'name', 'path', 'target']),
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/channel_config.py
+++ b/plugins/modules/channel_config.py
@@ -9,11 +9,11 @@ __metaclass__ = type
 from ..module_utils.dict_utils import diff_dicts
 from ..module_utils.fabric_utils import get_fabric_cfg_path
 from ..module_utils.file_utils import get_temp_file
+from ..module_utils.module import BlockchainModule
 from ..module_utils.msp_utils import convert_identity_to_msp_path
 from ..module_utils.proto_utils import proto_to_json, json_to_proto
 from ..module_utils.utils import get_console, get_identity_by_module, get_ordering_service_by_module, get_organizations_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from subprocess import CalledProcessError
 
@@ -484,7 +484,7 @@ def main():
         ('operation', 'sign_update', ['identity', 'msp_id', 'name', 'path']),
         ('operation', 'apply_update', ['api_endpoint', 'api_authtype', 'api_key', 'ordering_service', 'identity', 'msp_id', 'name', 'path'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/channel_member.py
+++ b/plugins/modules/channel_member.py
@@ -7,11 +7,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import equal_dicts, merge_dicts, copy_dict
+from ..module_utils.module import BlockchainModule
 from ..module_utils.msp_utils import organization_to_msp
 from ..module_utils.proto_utils import proto_to_json, json_to_proto
 from ..module_utils.utils import get_console, get_organization_by_module, get_peers_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import urllib
@@ -128,7 +128,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/channel_policy.py
+++ b/plugins/modules/channel_policy.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import equal_dicts, merge_dicts, copy_dict
+from ..module_utils.module import BlockchainModule
 from ..module_utils.proto_utils import proto_to_json, json_to_proto
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import json
@@ -83,7 +83,7 @@ def main():
     )
     required_if = [
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/connection_profile.py
+++ b/plugins/modules/connection_profile.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import equal_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_organization_by_module, get_certificate_authority_by_module, get_peers_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import base64
@@ -136,7 +136,7 @@ def main():
         ('api_authtype', 'basic', ['api_secret']),
         ('state', 'present', ['name', 'organization', 'peers'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/consortium_member.py
+++ b/plugins/modules/consortium_member.py
@@ -7,11 +7,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import equal_dicts, merge_dicts, copy_dict
+from ..module_utils.module import BlockchainModule
 from ..module_utils.msp_utils import organization_to_msp
 from ..module_utils.proto_utils import proto_to_json, json_to_proto
 from ..module_utils.utils import get_console, get_organization_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -116,7 +116,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/enrolled_identity.py
+++ b/plugins/modules/enrolled_identity.py
@@ -8,9 +8,9 @@ __metaclass__ = type
 
 from ..module_utils.certificate_authorities import CertificateAuthorityException
 from ..module_utils.enrolled_identities import EnrolledIdentity
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_certificate_authority_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import json
@@ -152,7 +152,7 @@ def main():
         ('api_authtype', 'basic', ['api_secret']),
         ('state', 'present', ['certificate_authority', 'name', 'enrollment_id', 'enrollment_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/enrolled_identity_info.py
+++ b/plugins/modules/enrolled_identity_info.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.enrolled_identities import EnrolledIdentity
+from ..module_utils.module import BlockchainModule
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import json
@@ -75,7 +75,7 @@ def main():
     argument_spec = dict(
         path=dict(type='str', required=True)
     )
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/external_ordering_service.py
+++ b/plugins/modules/external_ordering_service.py
@@ -7,10 +7,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import copy_dict, equal_dicts, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.ordering_services import OrderingService
 from ..module_utils.utils import get_console
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -247,7 +247,7 @@ def main():
     mutually_exclusive = [
         ['name', 'ordering_service']
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,

--- a/plugins/modules/external_organization.py
+++ b/plugins/modules/external_organization.py
@@ -7,10 +7,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import copy_dict, equal_dicts, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.organizations import Organization
 from ..module_utils.utils import get_console
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -423,7 +423,7 @@ def main():
     mutually_exclusive = [
         ['name', 'organization']
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,

--- a/plugins/modules/installed_chaincode.py
+++ b/plugins/modules/installed_chaincode.py
@@ -6,10 +6,10 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.proto_utils import proto_to_json
 from ..module_utils.utils import get_console, get_peer_by_module, get_identity_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import base64
@@ -166,7 +166,7 @@ def main():
         ['name', 'path'],
         ['version', 'path']
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,

--- a/plugins/modules/instantiated_chaincode.py
+++ b/plugins/modules/instantiated_chaincode.py
@@ -6,9 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_peer_by_module, get_identity_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import json
@@ -207,7 +207,7 @@ def main():
         ('api_authtype', 'basic', ['api_secret']),
         ('state', 'present', ['version'])
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if)

--- a/plugins/modules/ordering_service.py
+++ b/plugins/modules/ordering_service.py
@@ -8,9 +8,10 @@ __metaclass__ = type
 
 from ..module_utils.ordering_services import OrderingService
 from ..module_utils.dict_utils import merge_dicts, equal_dicts, copy_dict, diff_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_certificate_authority_by_module
 
-from ansible.module_utils.basic import AnsibleModule, _load_params
+from ansible.module_utils.basic import _load_params
 from ansible.module_utils._text import to_native
 
 import urllib
@@ -444,7 +445,7 @@ def main():
     mutually_exclusive = [
         ['certificate_authority', 'config']
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,

--- a/plugins/modules/ordering_service_admin.py
+++ b/plugins/modules/ordering_service_admin.py
@@ -7,11 +7,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import equal_dicts, copy_dict, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.msp_utils import organization_to_msp
 from ..module_utils.proto_utils import proto_to_json, json_to_proto
 from ..module_utils.utils import get_console, get_organization_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 import json
@@ -118,7 +118,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/ordering_service_info.py
+++ b/plugins/modules/ordering_service_info.py
@@ -6,9 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_ordering_service_by_name
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -156,7 +156,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/organization.py
+++ b/plugins/modules/organization.py
@@ -8,10 +8,10 @@ __metaclass__ = type
 
 from ..module_utils.cert_utils import split_ca_chain, equal_crls
 from ..module_utils.dict_utils import copy_dict, diff_dicts, equal_dicts, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.organizations import Organization
 from ..module_utils.utils import get_console, get_certificate_authority_by_module, get_identity_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 from ansible.module_utils._text import to_native
 
@@ -460,7 +460,7 @@ def main():
         ('api_authtype', 'basic', ['api_secret']),
         ('state', 'present', ['name', 'msp_id'])
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if)

--- a/plugins/modules/organization_info.py
+++ b/plugins/modules/organization_info.py
@@ -6,9 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_organization_by_name
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -211,7 +211,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import copy_dict, diff_dicts, equal_dicts, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.peers import Peer
 from ..module_utils.utils import get_console, get_certificate_authority_by_module
 
-from ansible.module_utils.basic import AnsibleModule, _load_params
+from ansible.module_utils.basic import _load_params
 from ansible.module_utils._text import to_native
 
 import urllib
@@ -467,7 +468,7 @@ def main():
     mutually_exclusive = [
         ['certificate_authority', 'config']
     ]
-    module = AnsibleModule(
+    module = BlockchainModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=required_if,

--- a/plugins/modules/peer_channel.py
+++ b/plugins/modules/peer_channel.py
@@ -6,10 +6,10 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.proto_utils import proto_to_json
 from ..module_utils.utils import get_console, get_identity_by_module, get_peer_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -154,7 +154,7 @@ def main():
         ('api_authtype', 'basic', ['api_secret']),
         ('operation', 'join', ['api_endpoint', 'api_authtype', 'api_key', 'peer', 'identity', 'msp_id', 'path']),
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/peer_info.py
+++ b/plugins/modules/peer_info.py
@@ -6,9 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_peer_by_name
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -134,7 +134,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret'])
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:

--- a/plugins/modules/registered_identity.py
+++ b/plugins/modules/registered_identity.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ..module_utils.dict_utils import copy_dict, equal_dicts, merge_dicts
+from ..module_utils.module import BlockchainModule
 from ..module_utils.utils import get_console, get_certificate_authority_by_module, get_identity_by_module
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -204,7 +204,7 @@ def main():
     required_if = [
         ('api_authtype', 'basic', ['api_secret']),
     ]
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
+    module = BlockchainModule(argument_spec=argument_spec, supports_check_mode=True, required_if=required_if)
 
     # Ensure all exceptions are caught.
     try:


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>

```
TASK [Import the ordering service] ***********************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: No module named 'hfc'
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (fabric-sdk-py) on Simons-MacBook-Pro-2.local's Python /Users/sstone1/.pyenv/versions/3.8.1/bin/python3.8. See https://ibm-blockchain.github.io/ansible-collection/installation.html#requirements for more info. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```