### PR TITLE
Don't send version in if it has not changed (resolves #289)

### DIFF
--- a/plugins/modules/certificate_authority.py
+++ b/plugins/modules/certificate_authority.py
@@ -518,6 +518,12 @@ def main():
                 if change not in permitted_changes:
                     raise Exception(f'{change} cannot be changed from {certificate_authority[change]} to {new_certificate_authority[change]} for existing certificate authority')
 
+            # HACK: if the version has not changed, do not send it in. The current
+            # version may not be supported by the current version of IBP.
+            if certificate_authority['version'] == new_certificate_authority['version']:
+                del certificate_authority['version']
+                del new_certificate_authority['version']
+
             # If the certificate authority has changed, apply the changes.
             certificate_authority_changed = not equal_dicts(certificate_authority, new_certificate_authority)
             if certificate_authority_changed:

--- a/plugins/modules/ordering_service.py
+++ b/plugins/modules/ordering_service.py
@@ -734,6 +734,12 @@ def main():
                     if change not in permitted_changes:
                         raise Exception(f'{change} cannot be changed from {ordering_service_node[change]} to {new_ordering_service_node[change]} for existing ordering service node')
 
+                # HACK: if the version has not changed, do not send it in. The current
+                # version may not be supported by the current version of IBP.
+                if ordering_service_node['version'] == new_ordering_service_node['version']:
+                    del ordering_service_node['version']
+                    del new_ordering_service_node['version']
+
                 # If the ordering service node has changed, apply the changes.
                 ordering_service_node_changed = not equal_dicts(ordering_service_node, new_ordering_service_node)
                 if ordering_service_node_changed:

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -678,6 +678,12 @@ def main():
                 if change not in permitted_changes:
                     raise Exception(f'{change} cannot be changed from {peer[change]} to {new_peer[change]} for existing peer')
 
+            # HACK: if the version has not changed, do not send it in. The current
+            # version may not be supported by the current version of IBP.
+            if peer['version'] == new_peer['version']:
+                del peer['version']
+                del new_peer['version']
+
             # If the peer has changed, apply the changes.
             peer_changed = not equal_dicts(peer, new_peer)
             if peer_changed:


### PR DESCRIPTION
If the version of IBM Blockchain Platform is upgraded, then the version of any existing components is no longer recognized, and sending it back to the update API results in a HTTP 500 status code. We probably don't want to send the version unless we're very sure.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>