### PR TITLE
Update installing.rst

### DIFF
--- a/docs/source/tutorials/installing.rst
+++ b/docs/source/tutorials/installing.rst
@@ -90,7 +90,7 @@ Create a new Ansible playbook file called `install-ibp.yml`. Copy and paste the 
           hosts: localhost
           vars:
             state: present
-            target: k8s
+            target: openshift
             arch: amd64
             project: ibpinfra
             image_registry_password: <image_registry_password>


### PR DESCRIPTION
In the RedHat OpenShift example, the target is incorrectly pointing to k8s when should be openshift