### PR TITLE
fix two minor points in peer & ordering service module

### DIFF
--- a/plugins/modules/ordering_service.py
+++ b/plugins/modules/ordering_service.py
@@ -323,6 +323,12 @@ EXAMPLES = '''
     api_key: xxxxxxxx
     api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     name: Ordering Service
+    # the following are required if this task is in a separate file
+    certificate_authority: Orderer Org CA
+    enrollment_id: orderingorgorderer
+    enrollment_secret: orderingorgordererpw
+    admin_certificates:
+      - LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0t...
 '''
 
 RETURN = '''

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -361,6 +361,12 @@ EXAMPLES = '''
     api_key: xxxxxxxx
     api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     name: Org1 Peer
+    # the following are required if this task is in a separate file
+    certificate_authority: Org1 CA
+    admins:
+        - LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0t...
+    enrollment_id: org1peer
+    enrollment_secret: org1peerpw
 '''
 
 RETURN = '''


### PR DESCRIPTION
It's very common to have "tear-down" tasks/playbook in a separate file, which would require more variables specified than the current document suggest. 

this PR fix the example