### PR TITLE
Update installing.rst (resolves #325)

### DIFF
--- a/docs/source/tutorials/installing.rst
+++ b/docs/source/tutorials/installing.rst
@@ -90,7 +90,7 @@ Create a new Ansible playbook file called `install-ibp.yml`. Copy and paste the 
           hosts: localhost
           vars:
             state: present
-            target: k8s
+            target: openshift
             arch: amd64
             project: ibpinfra
             image_registry_password: <image_registry_password>

--- a/tests/integration/targets/it_ordering_organization/tasks/main.yml
+++ b/tests/integration/targets/it_ordering_organization/tasks/main.yml
@@ -12,6 +12,7 @@
     organization_admin_enrollment_secret: orgadminpw
     ordering_service_enrollment_id: orderingservice
     ordering_service_enrollment_secret: orderingservicepw
+    ordering_service_name: "Test Ordering Service {{ short_test_run_id }}"
     k8s_namespace: "{{ k8s_namespace | mandatory }}"
     wait_timeout: "{{ wait_timeout | mandatory }}"
 


### PR DESCRIPTION
In the RedHat OpenShift example, the target is incorrectly pointing to k8s when should be openshift

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>
(kudos to @jinvanstee for the fix, cherry-picked it due to missing DCO)