### PR TITLE
Allow docker build to run in ocp without errors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 # In the first stage, install all the development packages, so we can build the native Python modules.
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
-RUN microdnf install gcc gzip python38 python38-devel tar
+RUN microdnf install gcc gzip python38 python38-devel tar && microdnf clean all
 RUN pip3.8 install --user ansible fabric-sdk-py python-pkcs11 openshift
 ENV PATH=/root/.local/bin:$PATH
 ADD https://galaxy.ansible.com/api/v2/collections/ibm/blockchain_platform /root/galaxy.json
@@ -12,7 +12,7 @@ RUN ansible-galaxy collection install ibm.blockchain_platform
 
 # In the second stage, build the Hyperledger Fabric binaries with HSM enabled (this is not the default).
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS fabric
-RUN microdnf install git make tar gzip which findutils gcc
+RUN microdnf install git make tar gzip which findutils gcc && microdnf clean all
 RUN curl -sSL https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar xzf - -C /usr/local
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$PATH
@@ -25,7 +25,7 @@ RUN cd /go/src/github.com/hyperledger/fabric \
 # In the third stage, copy all the installed Python modules across from the first stage and the Hyperledger
 # Fabric binaries from the second stage.
 FROM registry.access.redhat.com/ubi8/ubi-minimal
-RUN microdnf install python38
+RUN microdnf install python38 && microdnf clean all
 COPY --from=builder /root/.local /root/.local
 COPY --from=builder /root/.ansible /root/.ansible
 COPY --from=fabric /go/src/github.com/hyperledger/fabric/.build/bin /opt/fabric/bin


### PR DESCRIPTION
Allow docker build to run in ocp without errors

Previously you would get many errors of the form:

time="2020-07-31T15:19:52Z" level=error msg="Can't add file /var/lib/containers/storage/overlay/4a26cb563425c5e6d6018100bd171116608320fbc468da7ce062210f30784cc3/diff/var/cache/yum/metadata/rhel-8-for-x86_64-appstream-rpms-8-x86_64/gpgdir/S.gpg-agent to tar: archive/tar: sockets not supported"

This is caused by a problem in buildah:
containers/buildah#1888

The fix here implements the suggested workaround of adding 'microdnf clean all' to each 'microdnf install'

Signed-off-by: m-g-k <mgk@uk.ibm.com>