### PR TITLE
[477] Add missing Python dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install gcc gzip python38-devel tar \
     && microdnf clean all
 USER ibp-user
 ENV PATH=/home/ibp-user/.local/bin:$PATH
-RUN pip3.8 install --user "ansible>=2.9,<2.10" fabric-sdk-py python-pkcs11 openshift \
+RUN pip3.8 install --user "ansible>=2.9,<2.10" fabric-sdk-py python-pkcs11 openshift semantic_version \
     && chgrp -R root /home/ibp-user/.local \
     && chmod -R g=u /home/ibp-user/.local
 ADD . /tmp/collection


### PR DESCRIPTION
Issue #477 

The semantic_version dependency is no longer included in the dependency tree. Installing it as part of the image build process.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>