### PR TITLE
Provide Fabric v2.x binaries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ RUN mkdir -p /go/src/github.com/hyperledger \
     && cd /go/src/github.com/hyperledger \
     && git clone -n https://github.com/hyperledger/fabric.git \
     && cd fabric \
-    # FAB-18205 - allow communication with orderers with expired TLS certificates.
-    && git checkout 693cae5be282be51a48118ae4e8764e282b48cb8 \
+    && git checkout v2.2.1 \
     # FAB-18175 - ignore expired signer certificates when submitting transactions.
     && git remote add jyellick https://github.com/jyellick/fabric.git \
     && git fetch jyellick \
@@ -54,7 +53,7 @@ RUN cd /go/src/github.com/hyperledger/fabric \
 FROM base
 COPY --from=builder /home/ibp-user/.local /home/ibp-user/.local
 COPY --from=builder /home/ibp-user/.ansible /home/ibp-user/.ansible
-COPY --from=fabric /go/src/github.com/hyperledger/fabric/.build/bin /opt/fabric/bin
+COPY --from=fabric /go/src/github.com/hyperledger/fabric/build/bin /opt/fabric/bin
 COPY --from=fabric /go/src/github.com/hyperledger/fabric/sampleconfig /opt/fabric/config
 COPY docker/docker-entrypoint.sh /
 ENV FABRIC_CFG_PATH=/opt/fabric/config

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
     displayName: Use Python 3.x
   - script: pip install "ansible>=2.9,<2.10" ansible-doc-extractor ansible-lint flake8 fabric-sdk-py openshift python-pkcs11 semantic_version sphinx sphinx-rtd-theme yamllint yq
     displayName: Install Python dependencies
-  - script: curl -sSL https://github.com/hyperledger/fabric/releases/download/v1.4.7/hyperledger-fabric-linux-amd64-1.4.7.tar.gz | sudo tar xzf - -C /usr/local
+  - script: curl -sSL https://github.com/hyperledger/fabric/releases/download/v2.2.1/hyperledger-fabric-linux-amd64-2.2.1.tar.gz | sudo tar xzf - -C /usr/local
     displayName: Install Fabric CLI
   - script: |
       set -ex

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -54,17 +54,19 @@ In order to use this Ansible collection, you must have the following pre-requisi
 
         pip install ansible
 
-**Hyperledger Fabric v1.4.3+ binaries**
+**Hyperledger Fabric v2.2.1+ binaries**
 
-    This Ansible collection requires use of the binaries from Hyperledger Fabric v1.4.3 or later to interact with the peers and ordering services in your Hyperledger Fabric networks. These binaries include ``configtxlator`` and ``peer``.
+    This Ansible collection requires use of the binaries from Hyperledger Fabric v2.2.1 or later to interact with the peers and ordering services in your Hyperledger Fabric networks. These binaries include ``configtxlator`` and ``peer``.
 
-    You can install these binaries by following the Hyperledger Fabric documentation: https://hyperledger-fabric.readthedocs.io/en/release-1.4/install.html
+    You can install these binaries by following the Hyperledger Fabric documentation: https://hyperledger-fabric.readthedocs.io/en/release-2.2/install.html
 
     These binaries must be on the ``PATH`` of the system that will be used to run your Ansible Playbooks. You can check that the binaries are installed correctly by running:
 
     ::
 
         peer version
+
+    Note that the Hyperledger Fabric v2.x binaries can still be used to manage Hyperledger Fabric v1.4 networks. If you find that you must use Hyperledger Fabric v1.4 binaries, then you must use the binaries from Hyperledger Fabric v1.4.3 or later.
 
 **Hyperledger Fabric SDK for Python v0.8.1+**
 
@@ -163,7 +165,9 @@ You can run a playbook using this Docker image, by volume mounting the playbook 
 
 ::
 
-    docker run --rm -v /path/to/playbooks:/playbooks ibmcom/ibp-ansible ansible-playbook /playbooks/playbook.yml
+    docker run --rm -u $(id -u) -v /path/to/playbooks:/playbooks ibmcom/ibp-ansible ansible-playbook /playbooks/playbook.yml
+
+Note that the UID flag ``-u $(id -u)`` ensures that Ansible can write connection profile and identity files to the volume mount.
 
 The Docker image is supported for use in Docker, Kubernetes, and Red Hat OpenShift.
 

--- a/docs/source/tutorials/building.rst
+++ b/docs/source/tutorials/building.rst
@@ -98,13 +98,13 @@ If you have installed the collection by building a Docker image, then run the sc
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh build
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh build
 
 * Each organization has their own IBM Blockchain Platform instance:
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh -i build
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh -i build
 
 After the script has finished, you should examine the output of the script to check that no errors have occurred whilst running the Ansible playbooks. After each Ansible playbook runs, Ansible outputs a ``PLAY RECAP`` section that details how many tasks have been executed, and how many of those tasks have failed.
 
@@ -363,13 +363,13 @@ If you have installed the collection by building a Docker image, then run the sc
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh destroy
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh destroy
 
 * Each organization has their own IBM Blockchain Platform instance:
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh -i destroy
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/build_network.sh -i destroy
 
 After the script has finished, you should examine the output of the script to check that no errors have occurred whilst running the Ansible playbooks. After each Ansible playbook runs, Ansible outputs a ``PLAY RECAP`` section that details how many tasks have been executed, and how many of those tasks have failed.
 

--- a/docs/source/tutorials/deploying.rst
+++ b/docs/source/tutorials/deploying.rst
@@ -41,7 +41,7 @@ If you have installed the collection by building a Docker image, then run the sc
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/deploy_smart_contract.sh
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/deploy_smart_contract.sh
 
 Exploring the network
 ---------------------

--- a/docs/source/tutorials/joining.rst
+++ b/docs/source/tutorials/joining.rst
@@ -87,13 +87,13 @@ If you have installed the collection by building a Docker image, then run the sc
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh join
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh join
 
 * Each organization has their own IBM Blockchain Platform instance:
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh -i join
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh -i join
 
 After the script has finished, you should examine the output of the script to check that no errors have occurred whilst running the Ansible playbooks. After each Ansible playbook runs, Ansible outputs a ``PLAY RECAP`` section that details how many tasks have been executed, and how many of those tasks have failed.
 
@@ -263,13 +263,13 @@ If you have installed the collection by building a Docker image, then run the sc
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh destroy
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh destroy
 
 * All organizations have their own IBM Blockchain Platform instance:
 
     ::
 
-        docker run --rm -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh -i destroy
+        docker run --rm -u $(id -u) -v "$PWD:/tutorial" ibmcom/ibp-ansible /tutorial/join_network.sh -i destroy
 
 After the script has finished, you should examine the output of the script to check that no errors have occurred whilst running the Ansible playbooks. After each Ansible playbook runs, Ansible outputs a ``PLAY RECAP`` section that details how many tasks have been executed, and how many of those tasks have failed.
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@
 ---
 namespace: ibm
 name: blockchain_platform
-version: 0.0.50
+version: 0.0.51
 readme: README.md
 authors:
   - Simon Stone

--- a/tutorial/05-enable-capabilities.yml
+++ b/tutorial/05-enable-capabilities.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-- name: Enable V2 Capabilities
+- name: Enable Fabric v2.x capabilities
   hosts: localhost
   vars_files:
     - common-vars.yml


### PR DESCRIPTION
Also, add "-u $(id -u)" flag to Docker instructions to avoid permission problems on Linux.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>