### PR TITLE
fix: pass api_timeout to the peer commands

### DIFF
--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -334,7 +334,7 @@ class PeerConnection:
 
     def approve_chaincode(self, channel, name, version, package_id, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout):
         env = self._get_environ()
-        args = ['peer', 'lifecycle', 'chaincode', 'approveformyorg', '-C', channel, '-n', name, '-v', version, '--package-id', package_id, '--sequence', str(sequence), '--waitForEventTimeout', timeout]
+        args = ['peer', 'lifecycle', 'chaincode', 'approveformyorg', '-C', channel, '-n', name, '-v', version, '--package-id', package_id, '--sequence', str(sequence), '--waitForEventTimeout', str(timeout) + "s"]
         if endorsement_policy_ref:
             args.extend(['--channel-config-policy', endorsement_policy_ref])
         elif endorsement_policy:
@@ -375,7 +375,7 @@ class PeerConnection:
 
     def commit_chaincode(self, channel, msp_ids, name, version, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout):
         env = self._get_environ()
-        args = ['peer', 'lifecycle', 'chaincode', 'commit', '-C', channel, '-n', name, '-v', version, '--sequence', str(sequence), '--waitForEventTimeout', timeout]
+        args = ['peer', 'lifecycle', 'chaincode', 'commit', '-C', channel, '-n', name, '-v', version, '--sequence', str(sequence), '--waitForEventTimeout', str(timeout) + "s"]
         if endorsement_policy_ref:
             args.extend(['--channel-config-policy', endorsement_policy_ref])
         elif endorsement_policy:

--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -332,9 +332,9 @@ class PeerConnection:
         else:
             raise Exception(f'Failed to check commit readiness on peer: {process.stdout}')
 
-    def approve_chaincode(self, channel, name, version, package_id, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config):
+    def approve_chaincode(self, channel, name, version, package_id, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout):
         env = self._get_environ()
-        args = ['peer', 'lifecycle', 'chaincode', 'approveformyorg', '-C', channel, '-n', name, '-v', version, '--package-id', package_id, '--sequence', str(sequence)]
+        args = ['peer', 'lifecycle', 'chaincode', 'approveformyorg', '-C', channel, '-n', name, '-v', version, '--package-id', package_id, '--sequence', str(sequence), '--waitForEventTimeout', timeout]
         if endorsement_policy_ref:
             args.extend(['--channel-config-policy', endorsement_policy_ref])
         elif endorsement_policy:
@@ -373,9 +373,9 @@ class PeerConnection:
         else:
             raise Exception(f'Failed to query committed chaincode on peer: {process.stdout}')
 
-    def commit_chaincode(self, channel, msp_ids, name, version, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config):
+    def commit_chaincode(self, channel, msp_ids, name, version, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout):
         env = self._get_environ()
-        args = ['peer', 'lifecycle', 'chaincode', 'commit', '-C', channel, '-n', name, '-v', version, '--sequence', str(sequence)]
+        args = ['peer', 'lifecycle', 'chaincode', 'commit', '-C', channel, '-n', name, '-v', version, '--sequence', str(sequence), '--waitForEventTimeout', timeout]
         if endorsement_policy_ref:
             args.extend(['--channel-config-policy', endorsement_policy_ref])
         elif endorsement_policy:

--- a/plugins/modules/approved_chaincode.py
+++ b/plugins/modules/approved_chaincode.py
@@ -353,6 +353,7 @@ def main():
         validation_plugin = module.params['validation_plugin']
         init_required = module.params['init_required']
         collections_config = module.params['collections_config']
+        timeout = module.params['api_timeout']
 
         # We have to find out if it's already approved. To do this, we have to:
         # - Find out if a chaincode definition with the specified name, version, and sequence number exists.
@@ -393,7 +394,7 @@ def main():
 
             # Approve the chaincode.
             with peer.connect(module, identity, msp_id, hsm) as peer_connection:
-                peer_connection.approve_chaincode(channel, name, version, package_id, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config)
+                peer_connection.approve_chaincode(channel, name, version, package_id, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout)
                 changed = True
 
         # Return the approved chaincode.

--- a/plugins/modules/committed_chaincode.py
+++ b/plugins/modules/committed_chaincode.py
@@ -355,6 +355,7 @@ def main():
         validation_plugin = module.params['validation_plugin']
         init_required = module.params['init_required']
         collections_config = module.params['collections_config']
+        timeout = module.params['api_timeout']
 
         # Check if this chaincode is already committed on the channel.
         with peer.connect(module, identity, msp_id, hsm) as peer_connection:
@@ -387,7 +388,7 @@ def main():
 
             # Commit the chaincode.
             with peer.connect(module, identity, msp_id, hsm) as peer_connection:
-                peer_connection.commit_chaincode(channel, msp_ids, name, version, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config)
+                peer_connection.commit_chaincode(channel, msp_ids, name, version, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout)
                 changed = True
 
         # Return the committed chaincode.


### PR DESCRIPTION
For the 'lifecycle chaincode approve/commit' calls, pass the api_timeout
property to the --waitForEventTimeout

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>