### PR TITLE
Support K8S 1.22

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@
 ---
 namespace: ibm
 name: blockchain_platform
-version: 1.1.0
+version: 1.1.2
 readme: README.md
 authors:
   - Simon Stone/Matthew White

--- a/roles/console/tasks/k8s/create.yml
+++ b/roles/console/tasks/k8s/create.yml
@@ -147,7 +147,7 @@
 - name: Wait for console ingress to exist
   k8s_info:
     namespace: "{{ namespace }}"
-    api_version: extensions/v1beta1
+    api_version: networking.k8s.io/v1
     kind: Ingress
     name: "{{ console }}"
   register: console_route

--- a/roles/crds/templates/ca-crd.yml.j2
+++ b/roles/crds/templates/ca-crd.yml.j2
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -13,18 +13,16 @@ metadata:
     release: operator
   name: ibpcas.ibp.com
 spec:
-  preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: "{{ project | default(namespace) }}"
-        name: ibp-webhook
-        path: /crdconvert
-      caBundle: "{{ webhook_tls_cert }}"
-  validation:
-    openAPIV3Schema:
-      x-kubernetes-preserve-unknown-fields: true
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1alpha2", "v1alpha1"]
+      clientConfig:
+        service:
+          namespace: "{{ project | default(namespace) }}"
+          name: ibp-webhook
+          path: /crdconvert
+        caBundle: "{{ webhook_tls_cert }}"
   group: ibp.com
   names:
     kind: IBPCA
@@ -32,32 +30,53 @@ spec:
     plural: ibpcas
     singular: ibpca
   scope: Namespaced
-  subresources:
-    status: {}
-{%+ if product_version is version('2.5.1', '>=') %}
-  version: v1beta1
-{%+ else %}
-  version: v1alpha2
-{% endif %}
   versions:
-{%+ if product_version is version('2.5.1', '>=') %}
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
-{%+ else %}
-  - name: v1alpha2
-    served: true
-    storage: true
-{% endif %}
+    subresources:
+      status: {}
   - name: v210
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: false
     storage: false
+    subresources:
+      status: {}
   - name: v212
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: false
     storage: false
+    subresources:
+      status: {}
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: IBPCA
+    listKind: IBPCAList
+    plural: ibpcas
+    singular: ibpca
+  conditions: []
+  storedVersions:
+  - v1beta1

--- a/roles/crds/templates/console-crd.yml.j2
+++ b/roles/crds/templates/console-crd.yml.j2
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ibpconsoles.ibp.com
@@ -13,18 +13,16 @@ metadata:
     app.kubernetes.io/instance: "ibpconsole"
     app.kubernetes.io/managed-by: "ibp-operator"
 spec:
-  preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: "{{ project | default(namespace) }}"
-        name: ibp-webhook
-        path: /crdconvert
-      caBundle: "{{ webhook_tls_cert }}"
-  validation:
-    openAPIV3Schema:
-      x-kubernetes-preserve-unknown-fields: true
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1alpha2", "v1alpha1"]
+      clientConfig:
+        service:
+          namespace: "{{ project | default(namespace) }}"
+          name: ibp-webhook
+          path: /crdconvert
+        caBundle: "{{ webhook_tls_cert }}"
   group: ibp.com
   names:
     kind: IBPConsole
@@ -32,26 +30,37 @@ spec:
     plural: ibpconsoles
     singular: ibpconsole
   scope: Namespaced
-  subresources:
-    status: {}
-{%+ if product_version is version('2.5.1', '>=') %}
-  version: v1beta1
-{%+ else %}
-  version: v1alpha2
-{% endif %}
   versions:
-{%+ if product_version is version('2.5.1', '>=') %}
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
-{%+ else %}
-  - name: v1alpha2
-    served: true
-    storage: true
-{% endif %}
+    subresources:
+      status: {}
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: IBPConsole
+    listKind: IBPConsoleList
+    plural: ibpconsoles
+    singular: ibpconsole
+  conditions: []
+  storedVersions:
+  - v1beta1

--- a/roles/crds/templates/orderer-crd.yml.j2
+++ b/roles/crds/templates/orderer-crd.yml.j2
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ibporderers.ibp.com
@@ -13,18 +13,16 @@ metadata:
     app.kubernetes.io/instance: "ibporderer"
     app.kubernetes.io/managed-by: "ibp-operator"
 spec:
-  preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: "{{ project | default(namespace) }}"
-        name: ibp-webhook
-        path: /crdconvert
-      caBundle: "{{ webhook_tls_cert }}"
-  validation:
-    openAPIV3Schema:
-      x-kubernetes-preserve-unknown-fields: true
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1alpha2", "v1alpha1"]
+      clientConfig:
+        service:
+          namespace: "{{ project | default(namespace) }}"
+          name: ibp-webhook
+          path: /crdconvert
+        caBundle: "{{ webhook_tls_cert }}"
   group: ibp.com
   names:
     kind: IBPOrderer
@@ -32,26 +30,37 @@ spec:
     plural: ibporderers
     singular: ibporderer
   scope: Namespaced
-  subresources:
-    status: {}
-{%+ if product_version is version('2.5.1', '>=') %}
-  version: v1beta1
-{%+ else %}
-  version: v1alpha2
-{% endif %}
   versions:
-{%+ if product_version is version('2.5.1', '>=') %}
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
-{%+ else %}
-  - name: v1alpha2
-    served: true
-    storage: true
-{% endif %}
+    subresources:
+      status: {}
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: IBPOrderer
+    listKind: IBPOrdererList
+    plural: ibporderers
+    singular: ibporderer
+  conditions: []
+  storedVersions:
+  - v1beta1

--- a/roles/crds/templates/peer-crd.yml.j2
+++ b/roles/crds/templates/peer-crd.yml.j2
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ibppeers.ibp.com
@@ -13,18 +13,16 @@ metadata:
     app.kubernetes.io/instance: "ibppeer"
     app.kubernetes.io/managed-by: "ibp-operator"
 spec:
-  preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: "{{ project | default(namespace) }}"
-        name: ibp-webhook
-        path: /crdconvert
-      caBundle: "{{ webhook_tls_cert }}"
-  validation:
-    openAPIV3Schema:
-      x-kubernetes-preserve-unknown-fields: true
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1alpha2", "v1alpha1"]
+      clientConfig:
+        service:
+          namespace: "{{ project | default(namespace) }}"
+          name: ibp-webhook
+          path: /crdconvert
+        caBundle: "{{ webhook_tls_cert }}"
   group: ibp.com
   names:
     kind: IBPPeer
@@ -32,26 +30,37 @@ spec:
     plural: ibppeers
     singular: ibppeer
   scope: Namespaced
-  subresources:
-    status: {}
-{%+ if product_version is version('2.5.1', '>=') %}
-  version: v1beta1
-{%+ else %}
-  version: v1alpha2
-{% endif %}
   versions:
-{%+ if product_version is version('2.5.1', '>=') %}
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
-{%+ else %}
-  - name: v1alpha2
-    served: true
-    storage: true
-{% endif %}
+    subresources:
+      status: {}
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: IBPPeer
+    listKind: IBPPeerList
+    plural: ibppeers
+    singular: ibppeer
+  conditions: []
+  storedVersions:
+  - v1beta1

--- a/roles/hlfsupport_console/tasks/k8s/create.yml
+++ b/roles/hlfsupport_console/tasks/k8s/create.yml
@@ -147,7 +147,7 @@
 - name: Wait for console ingress to exist
   k8s_info:
     namespace: "{{ namespace }}"
-    api_version: extensions/v1beta1
+    api_version: networking.k8s.io/v1
     kind: Ingress
     name: "{{ console }}"
   register: console_route


### PR DESCRIPTION
Update the K8S APIs to latest versions, so 1.22 is supported
Make the version of the collection to be 1.1.2

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>