### PR TITLE
Reenrollment causes Authorisation Failure

### DIFF
--- a/plugins/modules/enrolled_identity.py
+++ b/plugins/modules/enrolled_identity.py
@@ -338,7 +338,7 @@ def main():
 
                 # If we need to re-enroll the certificate, do it now.
                 if reenroll_required:
-                    new_identity = connection.enroll(name, enrollment_id, enrollment_secret, hosts)
+                    new_identity = connection.reenroll(name, identity)
 
             # Check if it has changed.
             changed = not new_identity.equals(identity)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 ansible >= 2.9, <2.10
 ansible-doc-extractor
-ansible-lint == 5.0.3
+ansible-lint == 5.3.2
 flake8
 fabric-sdk-py
 openshift == 0.11.2


### PR DESCRIPTION
When setting 'force-reenroll' on the ansible enrolled_identity task
this would fail with an authorization error

Believe that the task was calling the wrong method on the 'fabric-ca-client'

Re-enrolling TLS created certs not supported

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>