### PR TITLE
Update the commands that call the peer binary to not capture stderr as stdout

### DIFF
--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -519,8 +519,9 @@ class PeerConnection:
     def _run_command(self, args, env):
         for attempt in range(1, self.retries + 1):
             self.module.json_log({'msg': 'running command', 'args': args, 'env': env, 'attempt': attempt})
-            process = subprocess.run(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, text=True, close_fds=True)
-            self.module.json_log({'msg': 'command finished', 'rc': process.returncode, 'stdout': process.stdout})
+            process = subprocess.run(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, text=True, close_fds=True)
+            self.module.json_log({'msg': 'command finished [stdout]', 'rc': process.returncode, 'stdout': process.stdout})
+            self.module.json_log({'msg': 'command finished [stderr]', 'rc': process.returncode, 'stdout': process.stderr})
             if process.returncode == 0:
                 return process
             elif attempt >= self.retries:


### PR DESCRIPTION
Update the commands that call the peer binary to not capture stderr as stdout

Instead it is routed to the log file.
Setting the fabric environment variable for debug would break as stdout was expected
to contain only JSON.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>