### PR TITLE
Support ansible 2.13

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,4 @@
 ---
 skip_list:
     - risky-file-permissions
+    - 'fqcn-builtins'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN microdnf install python38 shadow-utils \
 # In the second stage, install all the development packages, install the Python dependencies,
 # and then install the Ansible collection.
 FROM base AS builder
-RUN microdnf install gcc gzip python38-devel tar \
+RUN microdnf install gcc gzip python39-devel tar \
     && microdnf clean all
 USER ibp-user
 ENV PATH=/home/ibp-user/.local/bin:$PATH
-RUN pip3.8 install --user -U 'ansible>=2.9,<2.10' fabric-sdk-py python-pkcs11 'openshift==0.11.2' semantic_version \
+RUN pip3.9 install --user -U 'ansible' fabric-sdk-py python-pkcs11 'openshift' semantic_version \
     && chgrp -R root /home/ibp-user/.local \
     && chmod -R g=u /home/ibp-user/.local
 ADD . /tmp/collection

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -38,7 +38,7 @@ Requirements
 
 In order to use this Ansible collection, you must have the following pre-requisite software installed and available:
 
-**Python v3.7+**
+**Python v3.8+**
 
     Python can be installed from a variety of sources, including the package manager for your operating system (apt, yum, etc).
     If you install Python from the package manager for your operating system, you must also install the development libraries (usually a package named ``python3-devel``), as these are required when installing modules through ``pip``.
@@ -46,13 +46,13 @@ In order to use this Ansible collection, you must have the following pre-requisi
     - The official Python website: https://www.python.org/downloads/
     - The unofficial Python version manager: https://github.com/pyenv/pyenv
 
-**Ansible v2.8+**
+**Ansible v2.9+**
 
     Ansible can be installed from a variety of sources, including the package manager for your operating system (apt, yum, etc). You can also install it using ``pip``, the package manager for Python:
 
     ::
 
-        pip install -U 'ansible>=2.9,<2.10'
+        pip install -U 'ansible'
 
 **Hyperledger Fabric v2.2.1+ binaries**
 
@@ -96,7 +96,7 @@ In order to use this Ansible collection, you must have the following pre-requisi
 
     ::
 
-        pip install -U 'openshift==0.11.2'
+        pip install -U 'openshift'
 
 **Semantic Versioning for Python v2.8.5+**
 

--- a/docs/source/migrating-v12-v2.rst
+++ b/docs/source/migrating-v12-v2.rst
@@ -7,4 +7,6 @@ Migrating from v1.2 to version 2
 
 Consistent with a major version upgrade, the following are important changes between v1.2 and v2
 
-- tba
+- For the latest ansible(current is 2.13.1), Your python3 version should at least be 3.8.
+    python3.9 is used for the docker image. And we do not test against python3.11.
+- All the dependencies in requirent.txt should be the latest version.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9,<2.10"
+requires_ansible: ">=2.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-ansible >= 2.9, <2.10
+ansible
 ansible-doc-extractor
-ansible-lint == 5.3.2
+ansible-lint
 flake8
 fabric-sdk-py
-openshift == 0.11.2
+openshift
 python-pkcs11
 semantic_version
 sphinx


### PR DESCRIPTION
Update to support latest ansible

1. Use the latest ansible version
2. User python3.9.
3. Change ansible-lint to ignore the warning "fqcn-builtins"
4. Update other dependencies to latest