### PR TITLE
Change the default operator image from ibm-blockchain to hyperledger-labs

### DIFF
--- a/roles/fabric_operator_crds/defaults/main.yml
+++ b/roles/fabric_operator_crds/defaults/main.yml
@@ -21,7 +21,7 @@ orderer_image: "{{ fabric_container_registry }}/fabric-orderer"
 orderer_image_label: "{{ fabric_version }}"
 tools_image: "{{ fabric_container_registry }}/fabric-tools"
 tools_image_label: "{{ fabric_version }}"
-operator_image: ghcr.io/ibm-blockchain/fabric-operator
+operator_image: ghcr.io/hyperledger-labs/fabric-operator
 operator_image_label: latest-amd64
 init_image: registry.access.redhat.com/ubi8/ubi-minimal
 init_image_label: latest


### PR DESCRIPTION
This PR updates the default operator image to use the hyperledger-labs/fabric-operator.   The previous value was referencing the ibm-blockchain/fabric-operator, which was the staging ground for a transition to HLF, and is not the latest / stable operator build. 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>