### PR TITLE
adding custom TLS secret and HA deployment

### DIFF
--- a/roles/fabric_console/templates/k8s/hlf-operations-console.yaml.j2
+++ b/roles/fabric_console/templates/k8s/hlf-operations-console.yaml.j2
@@ -37,6 +37,16 @@ spec:
     console:
       class: "{{ console_storage_class }}"
       size: "{{ console_storage_size }}"
+{%+ if console_tls_secret is defined %}
+  tlsSecretName: "{{ console_tls_secret }}"
+{% endif %}
+{%+ if zones is defined %}
+  clusterdata:
+    zones:
+{%+ for zone in zones %}
+    - "{{ zone }}"
+{% endfor %}
+{% endif %}
   usetags: true
   version: 1.0.0
   resources:


### PR DESCRIPTION
This PR enables setting a custom TLS secret to be used by the TLS termination of the console and HA deployment of Fabric to multiple zones.

Signed-off-by: Arnaud van Gelder <arnaud.van.gelder-cic.netherlands@ibm.com>