### PR TITLE
Product Version Changes in console templates 

### DIFF
--- a/roles/console/templates/k8s/console.yml.j2
+++ b/roles/console/templates/k8s/console.yml.j2
@@ -25,10 +25,9 @@ spec:
   email: "{{ console_email }}"
   password: "{{ console_default_password }}"
   registryURL: "{{ image_registry_url }}"
-# Commented below to tune HLF support
-#{%+ if product_version is version('2.5.3', '>=') %}
+{%+ if product_version is version('1.0.5', '>=') %}
   usetags: true
-#{%+ endif %}
+{%+ endif %}
 {%+ if product_version is version('2.5.0', '>=') %}
   imagePullSecrets:
   - "{{ image_pull_secret }}"

--- a/roles/console/templates/k8s/console.yml.j2
+++ b/roles/console/templates/k8s/console.yml.j2
@@ -25,9 +25,10 @@ spec:
   email: "{{ console_email }}"
   password: "{{ console_default_password }}"
   registryURL: "{{ image_registry_url }}"
-{%+ if product_version is version('2.5.3', '>=') %}
+# Commented below to tune HLF support
+#{%+ if product_version is version('2.5.3', '>=') %}
   usetags: true
-{%+ endif %}
+#{%+ endif %}
 {%+ if product_version is version('2.5.0', '>=') %}
   imagePullSecrets:
   - "{{ image_pull_secret }}"

--- a/roles/console/templates/openshift/console.yml.j2
+++ b/roles/console/templates/openshift/console.yml.j2
@@ -25,9 +25,10 @@ spec:
   email: "{{ console_email }}"
   password: "{{ console_default_password }}"
   registryURL: "{{ image_registry_url }}"
-{%+ if product_version is version('2.5.3', '>=') %}
+# Commented below to tune HLF support
+# {%+ if product_version is version('2.5.3', '>=') %}
   usetags: true
-{%+ endif %}
+#{%+ endif %}
 {%+ if product_version is version('2.5.0', '>=') %}
   imagePullSecrets:
   - "{{ image_pull_secret }}"

--- a/roles/console/templates/openshift/console.yml.j2
+++ b/roles/console/templates/openshift/console.yml.j2
@@ -25,10 +25,9 @@ spec:
   email: "{{ console_email }}"
   password: "{{ console_default_password }}"
   registryURL: "{{ image_registry_url }}"
-# Commented below to tune HLF support
-# {%+ if product_version is version('2.5.3', '>=') %}
+{%+ if product_version is version('1.0.5', '>=') %}
   usetags: true
-#{%+ endif %}
+{%+ endif %}
 {%+ if product_version is version('2.5.0', '>=') %}
   imagePullSecrets:
   - "{{ image_pull_secret }}"


### PR DESCRIPTION
This change involves changes in the product version condition for the Console Jinja2 template under roles for K8 and open shift. This change is done to test the existing collection to run for the hlfsupport offering.

