### PR TITLE
Address the build error for required tags.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,6 +19,8 @@ tags:
   - hyperledger
   - fabric
   - blockchain
+  - infrastructure
+  - cloud
 repository: https://github.com/IBM-Blockchain/ansible-collection
 documentation: https://ibm-blockchain.github.io/ansible-collection/
 homepage: https://www.ibm.com/cloud/blockchain-platform


### PR DESCRIPTION
PRs were failing because we didn't have a required tag. This repository is deprecated, but we still need to do some final maintenance to get it to **show** as deprecated.